### PR TITLE
Add slugify utility with tests

### DIFF
--- a/tests/slugify.test.js
+++ b/tests/slugify.test.js
@@ -1,0 +1,11 @@
+const slugify = require('../utils/slugify');
+
+describe('slugify', () => {
+  test('converts spaces and punctuation', () => {
+    expect(slugify('Hello World!')).toBe('hello-world');
+  });
+
+  test('handles underscores and multiple spaces', () => {
+    expect(slugify('UPPER_case   Values!!')).toBe('upper-case-values');
+  });
+});

--- a/utils/slugify.js
+++ b/utils/slugify.js
@@ -1,0 +1,11 @@
+function slugify(str) {
+  return str
+    .toLowerCase()
+    .replace(/_/g, ' ')
+    .replace(/[^a-z0-9\s-]/g, '')
+    .trim()
+    .replace(/[\s-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+module.exports = slugify;


### PR DESCRIPTION
## Summary
- implement `utils/slugify.js` for generating URL slugs
- add tests for slugify utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6872736568cc8333bbbfedb6e481ff00